### PR TITLE
Bump cmake minimum version to 3.24, required for CMP0135 policy support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@
 project(GPU-Reshape)
 
 # Requirements
-cmake_minimum_required(VERSION 3.17)
+cmake_minimum_required(VERSION 3.24)
 
 # Policies
 cmake_policy(SET CMP0135 NEW)


### PR DESCRIPTION
I had an issue while trying to generate visual studio solutions. It turns out my cmake version was too old and according to the documentation (https://cmake.org/cmake/help/latest/policy/CMP0135.html) CMP0135 has only been introduced in cmake 3.24.