### PR TITLE
Fix metadata decoding and skip extra UAVs records

### DIFF
--- a/Source/Backends/DX12/Layer/Source/Compiler/DXIL/Blocks/DXILPhysicalBlockMetadata.cpp
+++ b/Source/Backends/DX12/Layer/Source/Compiler/DXIL/Blocks/DXILPhysicalBlockMetadata.cpp
@@ -454,11 +454,15 @@ void DXILPhysicalBlockMetadata::ParseResourceList(struct MetadataBlock& metadata
 
                     // Get extended record
                     const LLVMRecord &extendedRecord = block->records[extendedMetadata.source];
-                    ASSERT(extendedRecord.opCount == 2, "Expected 2 operands for extended metadata");
+                    ASSERT(extendedRecord.opCount == 2 || extendedRecord.opCount == 4, "Expected 2 or 4 operands for extended metadata");
 
                     // Parse tags
                     for (uint32_t kv = 0; kv < extendedRecord.opCount; kv += 2) {
                         switch (static_cast<DXILUAVTag>(GetOperandU32Constant(metadataBlock, extendedRecord.Op32(kv + 0)))) {
+                            default: {
+                                // Ignored
+                                break;
+                            }
                             case DXILUAVTag::ElementType: {
                                 // Get type
                                 auto componentType = GetOperandU32Constant<ComponentType>(metadataBlock, extendedRecord.Op32(kv + 1));
@@ -466,9 +470,6 @@ void DXILPhysicalBlockMetadata::ParseResourceList(struct MetadataBlock& metadata
                                 // Get type and format
                                 elementType = GetComponentType(componentType);
                                 format = GetComponentFormat(componentType);
-                                break;
-                            }
-                            case DXILUAVTag::ByteStride: {
                                 break;
                             }
                         }

--- a/Source/Backends/DX12/Layer/Source/Compiler/DXIL/Blocks/DXILPhysicalBlockMetadata.cpp
+++ b/Source/Backends/DX12/Layer/Source/Compiler/DXIL/Blocks/DXILPhysicalBlockMetadata.cpp
@@ -355,7 +355,7 @@ void DXILPhysicalBlockMetadata::ParseResourceList(struct MetadataBlock& metadata
 
                     // Parse tags
                     for (uint32_t kv = 0; kv < extendedRecord.opCount; kv += 2) {
-                        switch (static_cast<DXILSRVTag>(GetOperandU32Constant(metadataBlock, resource.Op32(kv + 0)))) {
+                        switch (static_cast<DXILSRVTag>(GetOperandU32Constant(metadataBlock, extendedRecord.Op32(kv + 0)))) {
                             case DXILSRVTag::ElementType: {
                                 // Get type
                                 auto componentType = GetOperandU32Constant<ComponentType>(metadataBlock, extendedRecord.Op32(kv + 1));
@@ -458,7 +458,7 @@ void DXILPhysicalBlockMetadata::ParseResourceList(struct MetadataBlock& metadata
 
                     // Parse tags
                     for (uint32_t kv = 0; kv < extendedRecord.opCount; kv += 2) {
-                        switch (static_cast<DXILUAVTag>(GetOperandU32Constant(metadataBlock, resource.Op32(kv + 0)))) {
+                        switch (static_cast<DXILUAVTag>(GetOperandU32Constant(metadataBlock, extendedRecord.Op32(kv + 0)))) {
                             case DXILUAVTag::ElementType: {
                                 // Get type
                                 auto componentType = GetOperandU32Constant<ComponentType>(metadataBlock, extendedRecord.Op32(kv + 1));

--- a/Source/Backends/DX12/Layer/Source/Compiler/DXIL/Blocks/DXILPhysicalBlockMetadata.cpp
+++ b/Source/Backends/DX12/Layer/Source/Compiler/DXIL/Blocks/DXILPhysicalBlockMetadata.cpp
@@ -454,7 +454,7 @@ void DXILPhysicalBlockMetadata::ParseResourceList(struct MetadataBlock& metadata
 
                     // Get extended record
                     const LLVMRecord &extendedRecord = block->records[extendedMetadata.source];
-                    ASSERT(extendedRecord.opCount == 2 || extendedRecord.opCount == 4, "Expected 2 or 4 operands for extended metadata");
+                    ASSERT(extendedRecord.opCount % 2 == 0, "Expected an even number of operands for extended metadata");
 
                     // Parse tags
                     for (uint32_t kv = 0; kv < extendedRecord.opCount; kv += 2) {


### PR DESCRIPTION
There is two different changes here, found while I was looking at an assert on a shader. I had 4 operands in my case (the shader was doing an atomic operation on a rwbuffer).

There is also another exising case for sampler feedback (found it here https://github.com/microsoft/DirectXShaderCompiler/blob/main/lib/DXIL/DxilMetadataHelper.cpp).

I just patched my specific case but we could instead remove the assert totally if that make more sense.