### PR TITLE
Fixed MSVC build on Release configurations

### DIFF
--- a/Source/Backends/DX12/Layer/Source/Compiler/ShaderCompiler.cpp
+++ b/Source/Backends/DX12/Layer/Source/Compiler/ShaderCompiler.cpp
@@ -283,8 +283,8 @@ IDXModule* ShaderCompiler::CompileSlimModule(IDXModule* sourceModule) {
 
             // Dump to console
             OutputDebugStringA(stream.str().c_str());
-#endif // NDEBUG
         }
+#endif // NDEBUG
 
         // Treat as complete failure
         return nullptr;


### PR DESCRIPTION
When I tried building GPU Reshape's development branch on MSVC in Release configuration I got a stream of compilation errors, the cause was a missing curly brace. The curly brace exists in Debug configurations, so the compilation error doesn't trigger there.