### PR TITLE
[Backend] fix crash when fragment shader contents is empty

### DIFF
--- a/Source/Backends/DX12/Layer/Source/Compiler/DXIL/DXILDebugModule.cpp
+++ b/Source/Backends/DX12/Layer/Source/Compiler/DXIL/DXILDebugModule.cpp
@@ -560,7 +560,7 @@ void DXILDebugModule::ParseContents(LLVMBlock* block, uint32_t fileMdId) {
         }
 
         // Deduce length
-        size_t fragmentLength = lastSourceEnd - lastSourceOffset;
+        size_t fragmentLength = lastSourceEnd > lastSourceOffset ? lastSourceEnd - lastSourceOffset : 0u;
 
         // Copy contents
         size_t contentOffset = fragment->contents.length();


### PR DESCRIPTION
if contents is empty, lastSourceEnd can be smaller than lastSourceOffset, resulting fragmentLength being -1 which is a very large number in uint64, then crashes becauses of out of memory when fragment->contents.resize trying to create a very big buffer.